### PR TITLE
Support for Omeka S 4.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ Copyright
 [Omeka S]: https://omeka.org/s
 [plugin Translations]: https://github.com/Daniel-KM/Omeka-plugin-Translations
 [Omeka Classic]: https://omeka.org/classic
+[installing a module]: https://omeka.org/s/docs/user-manual/modules/#installing-modules
 [poedit]: https://poedit.net
 [lokalize]: https://www.kde.org/applications/development/lokalize
-[plugin issues]: https://github.com/Daniel-KM/Omeka-plugin-Translations/issues
+[module issues]: https://github.com/Daniel-KM/Omeka-plugin-Translations/issues
 [CeCILL v2.1]: https://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html
 [GNU/GPL]: https://www.gnu.org/licenses/gpl-3.0.html
 [FSF]: https://www.fsf.org

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 Translations (module for Omeka S)
 =================================
 
-[Translations] is a module for [Omeka S] that allows to add specific
-translations of strings, in particular the hard-coded texts in the theme.
+[Translations] is a module for [Omeka S] that allows users to add their own
+translations of strings.
+
+As of Omeka S 4.0, both modules and themes are capable of providing translations
+on their own. However, this module may still be used to fill in missing
+translations or make overrides.
 
 In Omeka, the translations are managed with `.po` files in the directory `application/language/`
 for the core and in  the directory `language/` of each enabled module. This

--- a/config/module.ini
+++ b/config/module.ini
@@ -8,5 +8,5 @@ author_link  = "https://github.com/Daniel-KM"
 module_link  = "https://github.com/Daniel-KM/Omeka-S-module-Translations"
 support_link = "https://github.com/Daniel-KM/Omeka-S-module-Translations/issues"
 configurable = false
-version      = "3.0.2"
-omeka_version_constraint = "^1.0.0 || ^2.0.0 || ^3.0.0"
+version      = "3.0.3"
+omeka_version_constraint = "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"


### PR DESCRIPTION
Bumped the compatible Omeka S versions to include the recently released 4.0. The new version adds support for theme translations, so although this module may no longer be needed for that use case, we still use it to translate custom resource template labels.